### PR TITLE
Feature/hit clearing state

### DIFF
--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -109,8 +109,7 @@ namespace dwa_local_planner {
       base_local_planner::Trajectory findBestPath(
           tf::Stamped<tf::Pose> global_pose,
           tf::Stamped<tf::Pose> global_vel,
-          tf::Stamped<tf::Pose>& drive_velocities,
-          std::vector<geometry_msgs::Point> footprint_spec);
+          tf::Stamped<tf::Pose>& drive_velocities);
 
       /**
        * @brief  Take in a new global plan for the local planner to follow, and adjust local costmaps
@@ -141,6 +140,9 @@ namespace dwa_local_planner {
        * sets new plan and resets state
        */
       bool setPlan(const std::vector<geometry_msgs::PoseStamped>& orig_global_plan);
+
+
+     void setFootprintSpec(std::vector<geometry_msgs::Point> footprint_spec);
 
     private:
 

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -142,7 +142,7 @@ namespace dwa_local_planner {
       bool setPlan(const std::vector<geometry_msgs::PoseStamped>& orig_global_plan);
 
 
-     void setFootprintSpec(std::vector<geometry_msgs::Point> footprint_spec);
+      void setFootprintSpec(const std::vector<geometry_msgs::Point>& footprint_spec);
 
     private:
 
@@ -158,6 +158,7 @@ namespace dwa_local_planner {
       double forward_point_distance_;
 
       std::vector<geometry_msgs::PoseStamped> global_plan_;
+      std::vector<geometry_msgs::Point> robot_footprint_;
 
       boost::mutex configuration_mutex_;
       pcl::PointCloud<base_local_planner::MapGridCostPoint>* traj_cloud_;

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -183,7 +183,7 @@ namespace dwa_local_planner {
 
     void DWAPlanner::setFootprintSpec(const std::vector<geometry_msgs::Point>& footprint_spec)
     {
-      ROS_INFO("Setting footprint now!");
+      ROS_INFO("Received footprint and set it up!");
       obstacle_costs_.setFootprint(footprint_spec);
       robot_footprint_ = footprint_spec;
     }
@@ -222,6 +222,8 @@ namespace dwa_local_planner {
       Eigen::Vector3f vel,
       Eigen::Vector3f vel_samples){
 
+	// add debug message to check the footprint is set correctly
+	ROS_DEBUG_NAMED("dwaPlanner", "checkTrajectory() sets footprint with size %d", robot_footprint_.size());
 	obstacle_costs_.setFootprint(robot_footprint_);
     oscillation_costs_.resetOscillationFlags();
     base_local_planner::Trajectory traj;
@@ -303,6 +305,8 @@ namespace dwa_local_planner {
       tf::Stamped<tf::Pose> global_vel,
       tf::Stamped<tf::Pose>& drive_velocities) {
 
+	// add debug message to check the footprint is set correctly
+	ROS_DEBUG_NAMED("dwaPlanner", "findBestPath() sets footprint with size %d", robot_footprint_.size());
 	obstacle_costs_.setFootprint(robot_footprint_);
     //make sure that our configuration doesn't change mid-run
     boost::mutex::scoped_lock l(configuration_mutex_);

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -181,6 +181,12 @@ namespace dwa_local_planner {
     private_nh.param("cheat_factor", cheat_factor_, 1.0);
   }
 
+    void DWAPlanner::setFootprintSpec(std::vector<geometry_msgs::Point> footprint_spec)
+    {
+      ROS_INFO("Setting footprint now!");
+      obstacle_costs_.setFootprint(footprint_spec);
+    }
+
   // used for visualization only, total_costs are not really total costs
   bool DWAPlanner::getCellCosts(int cx, int cy, float &path_cost, float &goal_cost, float &occ_cost, float &total_cost) {
 
@@ -292,10 +298,7 @@ namespace dwa_local_planner {
   base_local_planner::Trajectory DWAPlanner::findBestPath(
       tf::Stamped<tf::Pose> global_pose,
       tf::Stamped<tf::Pose> global_vel,
-      tf::Stamped<tf::Pose>& drive_velocities,
-      std::vector<geometry_msgs::Point> footprint_spec) {
-
-    obstacle_costs_.setFootprint(footprint_spec);
+      tf::Stamped<tf::Pose>& drive_velocities) {
 
     //make sure that our configuration doesn't change mid-run
     boost::mutex::scoped_lock l(configuration_mutex_);

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -181,10 +181,11 @@ namespace dwa_local_planner {
     private_nh.param("cheat_factor", cheat_factor_, 1.0);
   }
 
-    void DWAPlanner::setFootprintSpec(std::vector<geometry_msgs::Point> footprint_spec)
+    void DWAPlanner::setFootprintSpec(const std::vector<geometry_msgs::Point>& footprint_spec)
     {
       ROS_INFO("Setting footprint now!");
       obstacle_costs_.setFootprint(footprint_spec);
+      robot_footprint_ = footprint_spec;
     }
 
   // used for visualization only, total_costs are not really total costs
@@ -220,6 +221,8 @@ namespace dwa_local_planner {
       Eigen::Vector3f pos,
       Eigen::Vector3f vel,
       Eigen::Vector3f vel_samples){
+
+	obstacle_costs_.setFootprint(robot_footprint_);
     oscillation_costs_.resetOscillationFlags();
     base_local_planner::Trajectory traj;
     geometry_msgs::PoseStamped goal_pose = global_plan_.back();
@@ -300,6 +303,7 @@ namespace dwa_local_planner {
       tf::Stamped<tf::Pose> global_vel,
       tf::Stamped<tf::Pose>& drive_velocities) {
 
+	obstacle_costs_.setFootprint(robot_footprint_);
     //make sure that our configuration doesn't change mid-run
     boost::mutex::scoped_lock l(configuration_mutex_);
 

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -112,6 +112,8 @@ namespace dwa_local_planner {
       //create the actual planner that we'll use.. it'll configure itself from the parameter server
       dp_ = boost::shared_ptr<DWAPlanner>(new DWAPlanner(name, &planner_util_));
 
+      dp_->setFootprintSpec(costmap_ros->getRobotFootprint());
+
       if( private_nh.getParam( "odom_topic", odom_topic_ ))
       {
         odom_helper_.setOdomTopic( odom_topic_ );
@@ -195,7 +197,7 @@ namespace dwa_local_planner {
     drive_cmds.frame_id_ = costmap_ros_->getBaseFrameID();
     
     // call with updated footprint
-    base_local_planner::Trajectory path = dp_->findBestPath(global_pose, robot_vel, drive_cmds, costmap_ros_->getRobotFootprint());
+    base_local_planner::Trajectory path = dp_->findBestPath(global_pose, robot_vel, drive_cmds);
     //ROS_ERROR("Best: %.2f, %.2f, %.2f, %.2f", path.xv_, path.yv_, path.thetav_, path.cost_);
 
     /* For timing uncomment

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -112,6 +112,7 @@ namespace dwa_local_planner {
       //create the actual planner that we'll use.. it'll configure itself from the parameter server
       dp_ = boost::shared_ptr<DWAPlanner>(new DWAPlanner(name, &planner_util_));
 
+      // set up footprint when initialization
       dp_->setFootprintSpec(costmap_ros->getRobotFootprint());
 
       if( private_nh.getParam( "odom_topic", odom_topic_ ))

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -677,7 +677,7 @@ namespace move_base {
         ROS_DEBUG_NAMED("move_base_plan_thread","Generated a plan from the base_global_planner");
 
         //make sure we only start the controller if we still haven't reached the goal
-        if(runPlanner_)
+        if(runPlanner_ && state_ != CLEARING)
           state_ = CONTROLLING;
         if(planner_frequency_ <= 0)
           runPlanner_ = false;


### PR DESCRIPTION
Two bugs fixed. When robot conducts pure rotation, the original code won't get footprint information and thus causes error. Also, fix state machine problem that the logic will never hit CLEARING state.