### PR TITLE
Update ExternalSpeedLimiter.cfg fixing timeout issue MOVEMENT-1641

### DIFF
--- a/base_local_planner/cfg/ExternalSpeedLimiter.cfg
+++ b/base_local_planner/cfg/ExternalSpeedLimiter.cfg
@@ -4,6 +4,6 @@
 from dynamic_reconfigure.parameter_generator_catkin import ParameterGenerator, double_t, int_t, bool_t
 gen = ParameterGenerator()
 
-gen.add("timeout", double_t, 0, "Time out old speed limits after this amount of time.  Negative value is no timeout [s]", 0.1, -1, 10)
+gen.add("timeout", double_t, 0, "Time out old speed limits after this amount of time.  Negative value is no timeout [s]", 0.25, -1, 10)
 
 exit(gen.generate("base_local_planner", "base_local_planner", "ExternalSpeedLimiter"))


### PR DESCRIPTION
https://6river.atlassian.net/browse/MOVEMENT-1641
The External speed limiter is failing because the updates and the timeouts function on two separate clocks, one in process time, one in real time. If the process time slows the real time timeout occurs and the chuck jerks as a result.