### PR TITLE
feat: add layer initialized state to costmap_layer MAP-131

### DIFF
--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -173,13 +173,13 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(tests static_tests)
   target_link_libraries(static_tests costmap_2d layers ${GTEST_LIBRARIES})
 
-#  add_executable(inflation_tests EXCLUDE_FROM_ALL test/inflation_tests.cpp)
-#  add_dependencies(tests inflation_tests)
-#  target_link_libraries(inflation_tests costmap_2d layers ${GTEST_LIBRARIES})
+  # add_executable(inflation_tests EXCLUDE_FROM_ALL test/inflation_tests.cpp)
+  # add_dependencies(tests inflation_tests)
+  # target_link_libraries(inflation_tests costmap_2d layers ${GTEST_LIBRARIES})
 
-#  add_executable(static_with_inflation_tests EXCLUDE_FROM_ALL test/static_with_inflation_tests.cpp)
-#  add_dependencies(tests static_with_inflation_tests)
-#  target_link_libraries(static_with_inflation_tests costmap_2d layers ${GTEST_LIBRARIES})
+  add_executable(static_with_inflation_tests EXCLUDE_FROM_ALL test/static_with_inflation_tests.cpp)
+  add_dependencies(tests static_with_inflation_tests)
+  target_link_libraries(static_with_inflation_tests costmap_2d layers ${GTEST_LIBRARIES})
 
   catkin_download_test_data(${PROJECT_NAME}_simple_driving_test_indexed.bag
     http://download.ros.osuosl.org/data/costmap_2d/simple_driving_test_indexed.bag
@@ -190,9 +190,9 @@ if(CATKIN_ENABLE_TESTING)
     DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/test
     MD5 e66b17ee374f2d7657972efcb3e2e4f7)
 
-#  add_rostest(test/footprint_tests.launch)
-#  add_rostest(test/inflation_tests.launch)
-#  add_rostest(test/static_with_inflation_tests.launch)
+  # add_rostest(test/footprint_tests.launch)
+  # add_rostest(test/inflation_tests.launch)
+  add_rostest(test/static_with_inflation_tests.launch)
   add_rostest(test/obstacle_tests.launch)
   add_rostest(test/simple_driving_test.xml)
   add_rostest(test/static_tests.launch)

--- a/costmap_2d/include/costmap_2d/aisle_bias_inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/aisle_bias_inflation_layer.h
@@ -83,6 +83,8 @@ public:
 
   virtual void reset() { onInitialize(); }
 
+  virtual void reInitailize() { reset(); }
+
   /** @brief  Given a distance, compute a cost.
    * @param  obs_distance The distance from an obstacle in cells
    * @param  vor_distance

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -111,6 +111,11 @@ public:
    */
   void resetLayers();
 
+    /**
+   * @brief Reset each individual layer
+   */
+  void reinitializeLayers();
+
   /** @brief Same as getLayeredCostmap()->isCurrent(). */
   bool isCurrent()
     {

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -100,6 +100,8 @@ public:
 
   virtual void reset() { onInitialize(); }
 
+  virtual void reinitialize() { reset(); }
+
   /** @brief  Given a distance, compute a cost.
    * @param  distance The distance from an obstacle in cells
    * @return A cost value for the distance */

--- a/costmap_2d/include/costmap_2d/layer.h
+++ b/costmap_2d/include/costmap_2d/layer.h
@@ -91,6 +91,8 @@ public:
 
   virtual void reset() {}
 
+  virtual void reinitialize() {}
+
   virtual ~Layer() {}
 
   /**

--- a/costmap_2d/include/costmap_2d/layer.h
+++ b/costmap_2d/include/costmap_2d/layer.h
@@ -84,10 +84,10 @@ public:
   virtual void updateCosts(Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j) {}
 
   /** @brief Stop publishers. */
-  virtual void deactivate() {}
+  virtual void deactivate() {layer_initialized_ = false;}
 
   /** @brief Restart publishers if they've been stopped. */
-  virtual void activate() {}
+  virtual void activate() {layer_initialized_ = true;}
 
   virtual void reset() {}
 
@@ -107,6 +107,9 @@ public:
   {
     return current_;
   }
+
+
+  bool layerInitialized() {return layer_initialized_;}
 
   /** @brief Implement this to make this layer match the size of the parent costmap. */
   virtual void matchSize() {}
@@ -173,6 +176,7 @@ protected:
   bool enabled_;  ///< Currently this var is managed by subclasses. TODO: make this managed by this class and/or container class.
   std::string name_;
   std::string shortname_;
+  bool layer_initialized_;
   tf::TransformListener* tf_;
 
 private:

--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -82,6 +82,8 @@ public:
     return global_frame_;
   }
 
+  bool areAllLayersInitialized();
+
   void resizeMap(unsigned int size_x, unsigned int size_y, double resolution, double origin_x, double origin_y,
                  bool size_locked = false);
 

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -77,6 +77,8 @@ public:
   virtual void deactivate();
   virtual void reset();
 
+  virtual void reinitialize() {reset();}
+
   /**
    * @brief  A callback to handle buffering LaserScan messages
    * @param message The message returned from a message notifier

--- a/costmap_2d/include/costmap_2d/obstacle_layer.h
+++ b/costmap_2d/include/costmap_2d/obstacle_layer.h
@@ -77,7 +77,7 @@ public:
   virtual void deactivate();
   virtual void reset();
 
-  virtual void reinitialize() {reset();}
+  virtual void reinitialize() { reset(); }
 
   /**
    * @brief  A callback to handle buffering LaserScan messages

--- a/costmap_2d/include/costmap_2d/obstruction_layer.h
+++ b/costmap_2d/include/costmap_2d/obstruction_layer.h
@@ -132,7 +132,7 @@ public:
   virtual void activate() override;
   virtual void deactivate() override;
   virtual void reset() override;
-  virtual void reinitialize() {reset();}
+  virtual void reinitialize() { reset(); }
 
   /**
    * @brief  A callback to handle buffering LaserScan messages

--- a/costmap_2d/include/costmap_2d/obstruction_layer.h
+++ b/costmap_2d/include/costmap_2d/obstruction_layer.h
@@ -132,6 +132,7 @@ public:
   virtual void activate() override;
   virtual void deactivate() override;
   virtual void reset() override;
+  virtual void reinitialize() {reset();}
 
   /**
    * @brief  A callback to handle buffering LaserScan messages

--- a/costmap_2d/include/costmap_2d/shadow_layer.h
+++ b/costmap_2d/include/costmap_2d/shadow_layer.h
@@ -67,7 +67,7 @@ public:
   virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
 
   virtual void reset();
-  virtual void reinitialize() {reset();}
+  virtual void reinitialize() { reset(); }
   virtual std::shared_ptr<std::vector<geometry_msgs::Point>> getShadowedObjects() {
     return shadowed_objects_;
   }

--- a/costmap_2d/include/costmap_2d/shadow_layer.h
+++ b/costmap_2d/include/costmap_2d/shadow_layer.h
@@ -67,7 +67,7 @@ public:
   virtual void updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j);
 
   virtual void reset();
-
+  virtual void reinitialize() {reset();}
   virtual std::shared_ptr<std::vector<geometry_msgs::Point>> getShadowedObjects() {
     return shadowed_objects_;
   }

--- a/costmap_2d/include/costmap_2d/static_layer.h
+++ b/costmap_2d/include/costmap_2d/static_layer.h
@@ -56,9 +56,10 @@ public:
   StaticLayer();
   virtual ~StaticLayer();
   virtual void onInitialize();
-  virtual void activate();
-  virtual void deactivate();
-  virtual void reset();
+  virtual void activate() override;
+  virtual void deactivate() override;
+  virtual void reset() override;
+  virtual void reinitialize() override;
 
   virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
                             double* max_x, double* max_y);

--- a/costmap_2d/include/costmap_2d/static_layer_with_inflation.h
+++ b/costmap_2d/include/costmap_2d/static_layer_with_inflation.h
@@ -70,6 +70,7 @@ public:
   virtual void activate() override;
   virtual void deactivate() override;
   virtual void reset() override;
+  virtual void reinitialize() override;
 
   virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,
                             double* max_x, double* max_y) override;

--- a/costmap_2d/include/costmap_2d/voronoi_inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/voronoi_inflation_layer.h
@@ -82,6 +82,7 @@ public:
   virtual void matchSize();
 
   virtual void reset() { onInitialize(); }
+  virtual void reInitialize() { reset(); }
 
   /** @brief  Given a distance, compute a cost.
    * @param  obs_distance The distance from an obstacle in cells

--- a/costmap_2d/plugins/aisle_bias_inflation_layer.cpp
+++ b/costmap_2d/plugins/aisle_bias_inflation_layer.cpp
@@ -90,6 +90,7 @@ void AisleBiasInflationLayer::onInitialize()
 
   matchSize();
   need_reinflation_ = true;
+  layer_initialized_ = true;
 }
 
 void AisleBiasInflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, uint32_t level)

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -94,8 +94,8 @@ void InflationLayer::onInitialize()
       dsrv_->setCallback(cb);
     }
   }
-
   matchSize();
+  layer_initialized_ = true;
 }
 
 void InflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, uint32_t level)

--- a/costmap_2d/plugins/obstacle_layer.cpp
+++ b/costmap_2d/plugins/obstacle_layer.cpp
@@ -229,9 +229,9 @@ void ObstacleLayer::onInitialize()
       observation_notifiers_.back()->setTargetFrames(target_frames);
     }
   }
-
   dsrv_ = NULL;
   setupDynamicReconfigure(nh);
+  layer_initialized_ = true;
 }
 
 void ObstacleLayer::setupDynamicReconfigure(ros::NodeHandle& nh)
@@ -593,6 +593,7 @@ void ObstacleLayer::activate()
     if (observation_buffers_[i])
       observation_buffers_[i]->resetLastUpdated();
   }
+  layer_initialized_ = true;
 }
 void ObstacleLayer::deactivate()
 {
@@ -601,6 +602,7 @@ void ObstacleLayer::deactivate()
     if (observation_subscribers_[i] != NULL)
       observation_subscribers_[i]->unsubscribe();
   }
+  layer_initialized_ = false;
 }
 
 void ObstacleLayer::updateRaytraceBounds(double ox, double oy, double wx, double wy, double range,

--- a/costmap_2d/plugins/obstruction_layer.cpp
+++ b/costmap_2d/plugins/obstruction_layer.cpp
@@ -242,6 +242,7 @@ void ObstructionLayer::onInitialize()
 
   dsrv_ = NULL;
   setupDynamicReconfigure(nh);
+  layer_initialized_ = true;
 }
 
 void ObstructionLayer::setupDynamicReconfigure(ros::NodeHandle& nh)
@@ -864,6 +865,7 @@ void ObstructionLayer::activate()
     if (observation_buffers_[i])
       observation_buffers_[i]->resetLastUpdated();
   }
+  layer_initialized_ = true;
 }
 void ObstructionLayer::deactivate()
 {
@@ -872,6 +874,7 @@ void ObstructionLayer::deactivate()
     if (observation_subscribers_[i] != NULL)
       observation_subscribers_[i]->unsubscribe();
   }
+  layer_initialized_ = false;
 }
 
 void ObstructionLayer::updateRaytraceBounds(double ox, double oy, double wx, double wy, double range,

--- a/costmap_2d/plugins/shadow_layer.cpp
+++ b/costmap_2d/plugins/shadow_layer.cpp
@@ -66,6 +66,7 @@ void ShadowLayer::onInitialize()
   setupDynamicReconfigure(nh);
 
   visualization_publisher_ = nh.advertise<visualization_msgs::Marker> ("shadow_points", 1);
+  layer_initialized_ = true;
 
 }
 

--- a/costmap_2d/plugins/voronoi_inflation_layer.cpp
+++ b/costmap_2d/plugins/voronoi_inflation_layer.cpp
@@ -89,6 +89,7 @@ void VoronoiInflationLayer::onInitialize()
   }
 
   matchSize();
+  layer_initialized_ = true;
 }
 
 void VoronoiInflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, uint32_t level)

--- a/costmap_2d/plugins/voxel_layer.cpp
+++ b/costmap_2d/plugins/voxel_layer.cpp
@@ -62,6 +62,7 @@ void VoxelLayer::onInitialize()
     voxel_pub_ = private_nh.advertise < costmap_2d::VoxelGrid > ("voxel_grid", 1);
 
   clearing_endpoints_pub_ = private_nh.advertise<sensor_msgs::PointCloud>("clearing_endpoints", 1);
+  layer_initialized_ = true;
 }
 
 void VoxelLayer::setupDynamicReconfigure(ros::NodeHandle& nh)

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -539,6 +539,19 @@ void Costmap2DROS::resetLayers()
   }
 }
 
+void Costmap2DROS::reinitializeLayers()
+{
+  Costmap2D* top = layered_costmap_->getCostmap();
+  top->resetMap(0, 0, top->getSizeInCellsX(), top->getSizeInCellsY());
+  std::vector < boost::shared_ptr<CostmapLayer> > *plugins = layered_costmap_->getPlugins();
+  for (vector<boost::shared_ptr<CostmapLayer> >::iterator plugin = plugins->begin(); plugin != plugins->end();
+      ++plugin)
+  {
+    ROS_INFO("plugin name is %s",(*plugin)->getName().c_str());
+    (*plugin)->reinitialize();
+  }
+}
+
 bool Costmap2DROS::getRobotPose(tf::Stamped<tf::Pose>& global_pose) const
 {
   global_pose.setIdentity();

--- a/costmap_2d/src/layered_costmap.cpp
+++ b/costmap_2d/src/layered_costmap.cpp
@@ -260,6 +260,17 @@ bool LayeredCostmap::isCurrent()
   return current_;
 }
 
+bool LayeredCostmap::areAllLayersInitialized() {
+  bool initialized = true;
+   for (vector<boost::shared_ptr<CostmapLayer> >::iterator plugin = plugins_.begin(); plugin != plugins_.end();
+      ++plugin)
+  {
+    initialized = initialized && (*plugin)->layerInitialized(); 
+  }
+
+  return initialized;
+}
+
 void LayeredCostmap::setFootprint(const std::vector<geometry_msgs::Point>& footprint_spec)
 {
   footprint_ = footprint_spec;

--- a/costmap_2d/test/obstacle_tests.cpp
+++ b/costmap_2d/test/obstacle_tests.cpp
@@ -448,7 +448,7 @@ TEST(costmap, ObstacleMapReset){
 }
 
 /**
- * Tests the reset method
+ * Tests the reinitialize method
  */
 TEST(costmap, ObstacleMapReinitailize){
 

--- a/costmap_2d/test/obstacle_tests.cpp
+++ b/costmap_2d/test/obstacle_tests.cpp
@@ -381,7 +381,7 @@ TEST(costmap, testMultipleAdditions){
 }
 
 /**
- * Tests the reset method
+ * Tests the onInitialize method
  */
 TEST(costmap, ObstacleMapOnInitialize){
 
@@ -396,7 +396,7 @@ TEST(costmap, ObstacleMapOnInitialize){
 }
 
 /**
- * Tests the reset method
+ * Tests the activate method
  */
 TEST(costmap, ObstacleMapDeactivated){
 
@@ -412,7 +412,7 @@ TEST(costmap, ObstacleMapDeactivated){
 }
 
 /**
- * Tests the reset method
+ * Tests the deactivate and activate method
  */
 TEST(costmap, ObstacleMapDeactivateAndActivate){
 

--- a/costmap_2d/test/obstacle_tests.cpp
+++ b/costmap_2d/test/obstacle_tests.cpp
@@ -447,6 +447,23 @@ TEST(costmap, ObstacleMapReset){
   ASSERT_EQ(layers.areAllLayersInitialized(), 1);
 }
 
+/**
+ * Tests the reset method
+ */
+TEST(costmap, ObstacleMapReinitailize){
+
+  tf::TransformListener tf;
+  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  ObstacleLayer* olayer = addObstacleLayer(layers, tf);
+
+  std::vector<boost::shared_ptr<CostmapLayer>>* plugin = layers.getPlugins();
+
+  (*(plugin->begin()))->reinitialize();
+
+  ASSERT_EQ((*(plugin->begin()))->layerInitialized(), 1);
+  ASSERT_EQ(olayer->layerInitialized(), 1);
+  ASSERT_EQ(layers.areAllLayersInitialized(), 1);
+}
 
 int main(int argc, char** argv){
   ros::init(argc, argv, "obstacle_tests");

--- a/costmap_2d/test/obstacle_tests.cpp
+++ b/costmap_2d/test/obstacle_tests.cpp
@@ -380,6 +380,73 @@ TEST(costmap, testMultipleAdditions){
 
 }
 
+/**
+ * Tests the reset method
+ */
+TEST(costmap, ObstacleMapOnInitialize){
+
+  tf::TransformListener tf;
+  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  ObstacleLayer* olayer = addObstacleLayer(layers, tf);
+
+  std::vector<boost::shared_ptr<CostmapLayer>>* plugin = layers.getPlugins();
+  ASSERT_EQ((*(plugin->begin()))->layerInitialized(), 1);
+  ASSERT_EQ(olayer->layerInitialized(), 1);
+  ASSERT_EQ(layers.areAllLayersInitialized(), 1);
+}
+
+/**
+ * Tests the reset method
+ */
+TEST(costmap, ObstacleMapDeactivated){
+
+  tf::TransformListener tf;
+  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  ObstacleLayer* olayer = addObstacleLayer(layers, tf);
+  std::vector<boost::shared_ptr<CostmapLayer>>* plugin = layers.getPlugins();
+  // call deactivate function
+  (*(plugin->begin()))->deactivate();
+  ASSERT_EQ((*(plugin->begin()))->layerInitialized(), 0);
+  ASSERT_EQ(olayer->layerInitialized(), 0);
+  ASSERT_EQ(layers.areAllLayersInitialized(), 0);
+}
+
+/**
+ * Tests the reset method
+ */
+TEST(costmap, ObstacleMapDeactivateAndActivate){
+
+  tf::TransformListener tf;
+  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  ObstacleLayer* olayer = addObstacleLayer(layers, tf);
+
+  std::vector<boost::shared_ptr<CostmapLayer>>* plugin = layers.getPlugins();
+  (*(plugin->begin()))->deactivate();
+  (*(plugin->begin()))->activate();
+
+  ASSERT_EQ((*(plugin->begin()))->layerInitialized(), 1);
+  ASSERT_EQ(olayer->layerInitialized(), 1);
+  ASSERT_EQ(layers.areAllLayersInitialized(), 1);
+}
+
+/**
+ * Tests the reset method
+ */
+TEST(costmap, ObstacleMapReset){
+
+  tf::TransformListener tf;
+  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  ObstacleLayer* olayer = addObstacleLayer(layers, tf);
+
+  std::vector<boost::shared_ptr<CostmapLayer>>* plugin = layers.getPlugins();
+
+  (*(plugin->begin()))->reset();
+
+  ASSERT_EQ((*(plugin->begin()))->layerInitialized(), 1);
+  ASSERT_EQ(olayer->layerInitialized(), 1);
+  ASSERT_EQ(layers.areAllLayersInitialized(), 1);
+}
+
 
 int main(int argc, char** argv){
   ros::init(argc, argv, "obstacle_tests");

--- a/costmap_2d/test/static_tests.cpp
+++ b/costmap_2d/test/static_tests.cpp
@@ -110,6 +110,22 @@ TEST(costmap, StaticMapReset){
 
 /**
  * Tests the reset method
+ */
+TEST(costmap, StaticMapReinitialize){
+
+  tf::TransformListener tf;
+  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  addStaticLayer(layers, tf);  // This adds the static map
+
+  std::vector<boost::shared_ptr<CostmapLayer>>* static_plugin = layers.getPlugins();
+
+  (*(static_plugin->begin()))->reinitialize();
+
+  ASSERT_EQ((*(static_plugin->begin()))->layerInitialized(), 1);
+  ASSERT_EQ(layers.areAllLayersInitialized(), 1);
+}
+/**
+ * Tests the reset method
  *
 TEST(costmap, testResetForStaticMap){
   // Define a static map with a large object in the center

--- a/costmap_2d/test/static_tests.cpp
+++ b/costmap_2d/test/static_tests.cpp
@@ -109,7 +109,7 @@ TEST(costmap, StaticMapReset){
 }
 
 /**
- * Tests the reset method
+ * Tests the reinitialize method
  */
 TEST(costmap, StaticMapReinitialize){
 

--- a/costmap_2d/test/static_tests.cpp
+++ b/costmap_2d/test/static_tests.cpp
@@ -46,7 +46,7 @@
 using namespace costmap_2d;
 
 /**
- * Tests the reset method
+ * Tests On Initialize method
  */
 TEST(costmap, StaticMapOnInitialize){
 
@@ -60,7 +60,7 @@ TEST(costmap, StaticMapOnInitialize){
 }
 
 /**
- * Tests the reset method
+ * Tests the deactivate method
  */
 TEST(costmap, StaticMapDeactivated){
 
@@ -75,7 +75,7 @@ TEST(costmap, StaticMapDeactivated){
 }
 
 /**
- * Tests the reset method
+ * Tests the deactivate and activate method
  */
 TEST(costmap, StaticMapDeactivateAndActivate){
 
@@ -119,11 +119,14 @@ TEST(costmap, testResetForStaticMap){
       staticMap.push_back(costmap_2d::LETHAL_OBSTACLE);
     }
   }
+
   // Allocate the cost map, with a inflation to 3 cells all around
   Costmap2D map(10, 10, RESOLUTION, 0.0, 0.0, 3, 3, 3, OBSTACLE_RANGE, MAX_Z, RAYTRACE_RANGE, 25, staticMap, THRESHOLD);
+
   // Populate the cost map with a wall around the perimeter. Free space should clear out the room.
   pcl::PointCloud<pcl::PointXYZ> cloud;
   cloud.points.resize(40);
+
   // Left wall
   unsigned int ind = 0;
   for (unsigned int i = 0; i < 10; i++){
@@ -132,22 +135,26 @@ TEST(costmap, testResetForStaticMap){
     cloud.points[ind].y = i;
     cloud.points[ind].z = MAX_Z;
     ind++;
+
     // Top
     cloud.points[ind].x = i;
     cloud.points[ind].y = 0;
     cloud.points[ind].z = MAX_Z;
     ind++;
+
     // Right
     cloud.points[ind].x = 9;
     cloud.points[ind].y = i;
     cloud.points[ind].z = MAX_Z;
     ind++;
+
     // Bottom
     cloud.points[ind].x = i;
     cloud.points[ind].y = 9;
     cloud.points[ind].z = MAX_Z;
     ind++;
   }
+
   double wx = 5.0, wy = 5.0;
   geometry_msgs::Point p;
   p.x = wx;
@@ -156,8 +163,10 @@ TEST(costmap, testResetForStaticMap){
   Observation obs(p, cloud, OBSTACLE_RANGE, RAYTRACE_RANGE);
   std::vector<Observation> obsBuf;
   obsBuf.push_back(obs);
+
   // Update the cost map for this observation
   map.updateWorld(wx, wy, obsBuf, obsBuf);
+
   // Verify that we now have only 36 cells with lethal cost, thus provong that we have correctly cleared
   // free space
   int hitCount = 0;
@@ -169,6 +178,7 @@ TEST(costmap, testResetForStaticMap){
     }
   }
   ASSERT_EQ(hitCount, 36);
+
   // Veriy that we have 64 non-leathal
   hitCount = 0;
   for(unsigned int i=0; i < 10; ++i){
@@ -178,6 +188,7 @@ TEST(costmap, testResetForStaticMap){
     }
   }
   ASSERT_EQ(hitCount, 64);
+
   // Now if we reset the cost map, we should have our map go back to being completely occupied
   map.resetMapOutsideWindow(wx, wy, 0.0, 0.0);
   //We should now go back to everything being occupied
@@ -232,146 +243,146 @@ TEST(costmap, testWindowCopy){
     //printf("\n");
   }
 
-}*/
+}
 
-//test for updating costmaps with static data
-// TEST(costmap, testFullyContainedStaticMapUpdate){
-//   Costmap2D map(5, 5, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS,
-//       10.0, MAX_Z, 10.0, 25, MAP_5_BY_5, THRESHOLD);
+test for updating costmaps with static data
+TEST(costmap, testFullyContainedStaticMapUpdate){
+  Costmap2D map(5, 5, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS,
+      10.0, MAX_Z, 10.0, 25, MAP_5_BY_5, THRESHOLD);
 
-//   Costmap2D static_map(GRID_WIDTH, GRID_HEIGHT, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS,
-//       10.0, MAX_Z, 10.0, 25, MAP_10_BY_10, THRESHOLD);
+  Costmap2D static_map(GRID_WIDTH, GRID_HEIGHT, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS,
+      10.0, MAX_Z, 10.0, 25, MAP_10_BY_10, THRESHOLD);
 
-//   map.updateStaticMapWindow(0, 0, 10, 10, MAP_10_BY_10);
+  map.updateStaticMapWindow(0, 0, 10, 10, MAP_10_BY_10);
 
-//   for(unsigned int i = 0; i < map.getSizeInCellsX(); ++i){
-//     for(unsigned int j = 0; j < map.getSizeInCellsY(); ++j){
-//       ASSERT_EQ(map.getCost(i, j), static_map.getCost(i, j));
-//     }
-//   }
-// }
+  for(unsigned int i = 0; i < map.getSizeInCellsX(); ++i){
+    for(unsigned int j = 0; j < map.getSizeInCellsY(); ++j){
+      ASSERT_EQ(map.getCost(i, j), static_map.getCost(i, j));
+    }
+  }
+}
 
-// TEST(costmap, testOverlapStaticMapUpdate){
-//   Costmap2D map(5, 5, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS,
-//       10.0, MAX_Z, 10.0, 25, MAP_5_BY_5, THRESHOLD);
+TEST(costmap, testOverlapStaticMapUpdate){
+  Costmap2D map(5, 5, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS,
+      10.0, MAX_Z, 10.0, 25, MAP_5_BY_5, THRESHOLD);
 
-//   Costmap2D static_map(GRID_WIDTH, GRID_HEIGHT, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS,
-//       10.0, MAX_Z, 10.0, 25, MAP_10_BY_10, THRESHOLD);
+  Costmap2D static_map(GRID_WIDTH, GRID_HEIGHT, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS,
+      10.0, MAX_Z, 10.0, 25, MAP_10_BY_10, THRESHOLD);
 
-//   map.updateStaticMapWindow(-10, -10, 10, 10, MAP_10_BY_10);
+  map.updateStaticMapWindow(-10, -10, 10, 10, MAP_10_BY_10);
 
-//   ASSERT_FLOAT_EQ(map.getOriginX(), -10);
-//   ASSERT_FLOAT_EQ(map.getOriginX(), -10);
-//   ASSERT_EQ(map.getSizeInCellsX(), (unsigned int)15);
-//   ASSERT_EQ(map.getSizeInCellsY(), (unsigned int)15);
-//   for(unsigned int i = 0; i < 10; ++i){
-//     for(unsigned int j = 0; j < 10; ++j){
-//       ASSERT_EQ(map.getCost(i, j), static_map.getCost(i, j));
-//     }
-//   }
+  ASSERT_FLOAT_EQ(map.getOriginX(), -10);
+  ASSERT_FLOAT_EQ(map.getOriginX(), -10);
+  ASSERT_EQ(map.getSizeInCellsX(), (unsigned int)15);
+  ASSERT_EQ(map.getSizeInCellsY(), (unsigned int)15);
+  for(unsigned int i = 0; i < 10; ++i){
+    for(unsigned int j = 0; j < 10; ++j){
+      ASSERT_EQ(map.getCost(i, j), static_map.getCost(i, j));
+    }
+  }
 
-//   std::vector<unsigned char> blank(100);
+  std::vector<unsigned char> blank(100);
 
-//   //check to make sure that inflation on updates are being done correctly
-//   map.updateStaticMapWindow(-10, -10, 10, 10, blank);
+  //check to make sure that inflation on updates are being done correctly
+  map.updateStaticMapWindow(-10, -10, 10, 10, blank);
 
-//   for(unsigned int i = 0; i < map.getSizeInCellsX(); ++i){
-//     for(unsigned int j = 0; j < map.getSizeInCellsY(); ++j){
-//       ASSERT_EQ(map.getCost(i, j), 0);
-//     }
-//   }
+  for(unsigned int i = 0; i < map.getSizeInCellsX(); ++i){
+    for(unsigned int j = 0; j < map.getSizeInCellsY(); ++j){
+      ASSERT_EQ(map.getCost(i, j), 0);
+    }
+  }
 
-//   std::vector<unsigned char> fully_contained(25);
-//   fully_contained[0] = 254;
-//   fully_contained[4] = 254;
-//   fully_contained[5] = 254;
-//   fully_contained[9] = 254;
+  std::vector<unsigned char> fully_contained(25);
+  fully_contained[0] = 254;
+  fully_contained[4] = 254;
+  fully_contained[5] = 254;
+  fully_contained[9] = 254;
 
-//   Costmap2D small_static_map(5, 5, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS,
-//       10.0, MAX_Z, 10.0, 25, fully_contained, THRESHOLD);
+  Costmap2D small_static_map(5, 5, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS,
+      10.0, MAX_Z, 10.0, 25, fully_contained, THRESHOLD);
 
-//   map.updateStaticMapWindow(0, 0, 5, 5, fully_contained);
+  map.updateStaticMapWindow(0, 0, 5, 5, fully_contained);
 
-//   ASSERT_FLOAT_EQ(map.getOriginX(), -10);
-//   ASSERT_FLOAT_EQ(map.getOriginX(), -10);
-//   ASSERT_EQ(map.getSizeInCellsX(), (unsigned int)15);
-//   ASSERT_EQ(map.getSizeInCellsY(), (unsigned int)15);
-//   for(unsigned int j = 0; j < 5; ++j){
-//     for(unsigned int i = 0; i < 5; ++i){
-//       ASSERT_EQ(map.getCost(i + 10, j + 10), small_static_map.getCost(i, j));
-//     }
-//   }
+  ASSERT_FLOAT_EQ(map.getOriginX(), -10);
+  ASSERT_FLOAT_EQ(map.getOriginX(), -10);
+  ASSERT_EQ(map.getSizeInCellsX(), (unsigned int)15);
+  ASSERT_EQ(map.getSizeInCellsY(), (unsigned int)15);
+  for(unsigned int j = 0; j < 5; ++j){
+    for(unsigned int i = 0; i < 5; ++i){
+      ASSERT_EQ(map.getCost(i + 10, j + 10), small_static_map.getCost(i, j));
+    }
+  }
 
-// }
-
-
-// TEST(costmap, testStaticMap){
-//   Costmap2D map(GRID_WIDTH, GRID_HEIGHT, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS, 
-//       10.0, MAX_Z, 10.0, 25, MAP_10_BY_10, THRESHOLD);
-
-//   ASSERT_EQ(map.getSizeInCellsX(), (unsigned int)10);
-//   ASSERT_EQ(map.getSizeInCellsY(), (unsigned int)10);
-
-//   // Verify that obstacles correctly identified from the static map.
-//   std::vector<unsigned int> occupiedCells;
-
-//   for(unsigned int i = 0; i < 10; ++i){
-//     for(unsigned int j = 0; j < 10; ++j){
-//       if(map.getCost(i, j) == costmap_2d::LETHAL_OBSTACLE){
-//         occupiedCells.push_back(map.getIndex(i, j));
-//       }
-//     }
-//   }
-
-//   ASSERT_EQ(occupiedCells.size(), (unsigned int)20);
-
-//   // Iterate over all id's and verify that they are present according to their
-//   for(std::vector<unsigned int>::const_iterator it = occupiedCells.begin(); it != occupiedCells.end(); ++it){
-//     unsigned int ind = *it;
-//     unsigned int x, y;
-//     map.indexToCells(ind, x, y);
-//     ASSERT_EQ(find(occupiedCells, map.getIndex(x, y)), true);
-//     ASSERT_EQ(MAP_10_BY_10[ind] >= 100, true);
-//     ASSERT_EQ(map.getCost(x, y) >= 100, true);
-//   }
-
-//   // Block of 200
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(7, 2)), true);
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(8, 2)), true);
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(9, 2)), true);
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(7, 3)), true);
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(8, 3)), true);
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(9, 3)), true);
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(7, 4)), true);
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(8, 4)), true);
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(9, 4)), true);
-
-//   // Block of 100
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(4, 3)), true);
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(4, 4)), true);
-
-//   // Block of 200
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(3, 7)), true);
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(4, 7)), true);
-//   ASSERT_EQ(find(occupiedCells, map.getIndex(5, 7)), true);
+}
 
 
-//   // Verify Coordinate Transformations, ROW MAJOR ORDER
-//   ASSERT_EQ(worldToIndex(map, 0.0, 0.0), (unsigned int)0);
-//   ASSERT_EQ(worldToIndex(map, 0.0, 0.99), (unsigned int)0);
-//   ASSERT_EQ(worldToIndex(map, 0.0, 1.0), (unsigned int)10);
-//   ASSERT_EQ(worldToIndex(map, 1.0, 0.99), (unsigned int)1);
-//   ASSERT_EQ(worldToIndex(map, 9.99, 9.99), (unsigned int)99);
-//   ASSERT_EQ(worldToIndex(map, 8.2, 3.4), (unsigned int)38);
+TEST(costmap, testStaticMap){
+  Costmap2D map(GRID_WIDTH, GRID_HEIGHT, RESOLUTION, 0.0, 0.0, ROBOT_RADIUS, ROBOT_RADIUS, ROBOT_RADIUS, 
+      10.0, MAX_Z, 10.0, 25, MAP_10_BY_10, THRESHOLD);
 
-//   // Ensure we hit the middle of the cell for world co-ordinates
-//   double wx, wy;
-//   indexToWorld(map, 99, wx, wy);
-//   ASSERT_EQ(wx, 9.5);
-//   ASSERT_EQ(wy, 9.5);
-// }
+  ASSERT_EQ(map.getSizeInCellsX(), (unsigned int)10);
+  ASSERT_EQ(map.getSizeInCellsY(), (unsigned int)10);
 
-//*/
+  // Verify that obstacles correctly identified from the static map.
+  std::vector<unsigned int> occupiedCells;
+
+  for(unsigned int i = 0; i < 10; ++i){
+    for(unsigned int j = 0; j < 10; ++j){
+      if(map.getCost(i, j) == costmap_2d::LETHAL_OBSTACLE){
+        occupiedCells.push_back(map.getIndex(i, j));
+      }
+    }
+  }
+
+  ASSERT_EQ(occupiedCells.size(), (unsigned int)20);
+
+  // Iterate over all id's and verify that they are present according to their
+  for(std::vector<unsigned int>::const_iterator it = occupiedCells.begin(); it != occupiedCells.end(); ++it){
+    unsigned int ind = *it;
+    unsigned int x, y;
+    map.indexToCells(ind, x, y);
+    ASSERT_EQ(find(occupiedCells, map.getIndex(x, y)), true);
+    ASSERT_EQ(MAP_10_BY_10[ind] >= 100, true);
+    ASSERT_EQ(map.getCost(x, y) >= 100, true);
+  }
+
+  // Block of 200
+  ASSERT_EQ(find(occupiedCells, map.getIndex(7, 2)), true);
+  ASSERT_EQ(find(occupiedCells, map.getIndex(8, 2)), true);
+  ASSERT_EQ(find(occupiedCells, map.getIndex(9, 2)), true);
+  ASSERT_EQ(find(occupiedCells, map.getIndex(7, 3)), true);
+  ASSERT_EQ(find(occupiedCells, map.getIndex(8, 3)), true);
+  ASSERT_EQ(find(occupiedCells, map.getIndex(9, 3)), true);
+  ASSERT_EQ(find(occupiedCells, map.getIndex(7, 4)), true);
+  ASSERT_EQ(find(occupiedCells, map.getIndex(8, 4)), true);
+  ASSERT_EQ(find(occupiedCells, map.getIndex(9, 4)), true);
+
+  // Block of 100
+  ASSERT_EQ(find(occupiedCells, map.getIndex(4, 3)), true);
+  ASSERT_EQ(find(occupiedCells, map.getIndex(4, 4)), true);
+
+  // Block of 200
+  ASSERT_EQ(find(occupiedCells, map.getIndex(3, 7)), true);
+  ASSERT_EQ(find(occupiedCells, map.getIndex(4, 7)), true);
+  ASSERT_EQ(find(occupiedCells, map.getIndex(5, 7)), true);
+
+
+  // Verify Coordinate Transformations, ROW MAJOR ORDER
+  ASSERT_EQ(worldToIndex(map, 0.0, 0.0), (unsigned int)0);
+  ASSERT_EQ(worldToIndex(map, 0.0, 0.99), (unsigned int)0);
+  ASSERT_EQ(worldToIndex(map, 0.0, 1.0), (unsigned int)10);
+  ASSERT_EQ(worldToIndex(map, 1.0, 0.99), (unsigned int)1);
+  ASSERT_EQ(worldToIndex(map, 9.99, 9.99), (unsigned int)99);
+  ASSERT_EQ(worldToIndex(map, 8.2, 3.4), (unsigned int)38);
+
+  // Ensure we hit the middle of the cell for world co-ordinates
+  double wx, wy;
+  indexToWorld(map, 99, wx, wy);
+  ASSERT_EQ(wx, 9.5);
+  ASSERT_EQ(wy, 9.5);
+}
+
+*/
 
 
 int main(int argc, char** argv){

--- a/costmap_2d/test/static_with_inflation_tests.cpp
+++ b/costmap_2d/test/static_with_inflation_tests.cpp
@@ -85,7 +85,6 @@ TEST(costmap, testTimeMapUpdatesNominal) {
   addStaticLayer(layers, tf);
 
   ObstacleLayer* olayer = addObstacleLayer(layers, tf);
-  // InflationLayer* ilayer = addInflationLayer(layers, tf);
 
   std::vector<geometry_msgs::Point> polygon = setRadii(layers, 1, 1.75, 3);
   layers.setFootprint(polygon);
@@ -108,7 +107,6 @@ TEST(costmap, testTimeMapUpdatesNominal) {
   // obstacle count == static layer obstacle count
   Costmap2D* costmap = layers.getCostmap();
   ASSERT_EQ(countValues(*costmap, costmap_2d::LETHAL_OBSTACLE), BIGMAP_OBSTACLES);
-  
 
   std::default_random_engine generator;
   std::uniform_real_distribution<double> distribution(-OBSTRUCTION_SPREAD, OBSTRUCTION_SPREAD);
@@ -195,7 +193,7 @@ TEST(costmap, testTimeMapUpdatesNew) {
     olayer->clearStaticObservations(true, true);
   }
   std::cerr << "Time for next updates " << (double)sw.elapsedMicroseconds() / NUM_UPDATES << " ms per update" << std::endl;
-  
+
   // Print result and verify the correct number of obstacles
   costmap = layers.getCostmap();
   ASSERT_EQ(countValues(*costmap, costmap_2d::LETHAL_OBSTACLE), BIGMAP_OBSTACLES + NUM_UPDATES * NUM_OBSTACLES);
@@ -265,7 +263,7 @@ TEST(costmap, StaticLayerWithInflationMapReset){
 }
 
 /**
- * Tests the reset method
+ * Tests the reinitialize method
  */
 TEST(costmap, StaticLayerWithInflationMapReinitialize){
 

--- a/costmap_2d/test/static_with_inflation_tests.cpp
+++ b/costmap_2d/test/static_with_inflation_tests.cpp
@@ -28,7 +28,7 @@
  */
 
 /**
- * @author Daniel Grieneisen
+ * @author Daniel Grieneisen, Sindhura Chayapathy
  * Test harness for StaticLayerWithInflation for Costmap2D
  */
 
@@ -201,6 +201,68 @@ TEST(costmap, testTimeMapUpdatesNew) {
   ASSERT_EQ(countValues(*costmap, costmap_2d::LETHAL_OBSTACLE), BIGMAP_OBSTACLES + NUM_UPDATES * NUM_OBSTACLES);
 }
 
+/**
+ * Tests the reset method
+ */
+TEST(costmap, StaticLayerWithInflationMapOnInitialize){
+
+  tf::TransformListener tf;
+  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  addStaticLayerWithInflation(layers, tf);  // This adds the StaticLayerWithInflation map
+
+  std::vector<boost::shared_ptr<CostmapLayer>>* plugin = layers.getPlugins();
+  ASSERT_EQ((*(plugin->begin()))->layerInitialized(), 1);
+  ASSERT_EQ(layers.areAllLayersInitialized(), 1);
+}
+
+/**
+ * Tests the reset method
+ */
+TEST(costmap, StaticLayerWithInflationMapDeactivated){
+
+  tf::TransformListener tf;
+  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  addStaticLayerWithInflation(layers, tf);  // This adds the StaticInflation map
+  std::vector<boost::shared_ptr<CostmapLayer>>* plugin = layers.getPlugins();
+  // call deactivate function
+  (*(plugin->begin()))->deactivate();
+  ASSERT_EQ((*(plugin->begin()))->layerInitialized(), 0);
+  ASSERT_EQ(layers.areAllLayersInitialized(), 0);
+}
+
+/**
+ * Tests the reset method
+ */
+TEST(costmap, StaticLayerWithInflationMapDeactivateAndActivate){
+
+  tf::TransformListener tf;
+  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  addStaticLayerWithInflation(layers, tf);  // This adds the StaticInflation map
+
+  std::vector<boost::shared_ptr<CostmapLayer>>* plugin = layers.getPlugins();
+  (*(plugin->begin()))->deactivate();
+  (*(plugin->begin()))->activate();
+
+  ASSERT_EQ((*(plugin->begin()))->layerInitialized(), 1);
+  ASSERT_EQ(layers.areAllLayersInitialized(), 1);
+}
+
+/**
+ * Tests the reset method
+ */
+TEST(costmap, StaticLayerWithInflationMapReset){
+
+  tf::TransformListener tf;
+  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  addStaticLayerWithInflation(layers, tf);  // This adds the StaticLayerWithInflation map
+
+  std::vector<boost::shared_ptr<CostmapLayer>>* plugin = layers.getPlugins();
+
+  (*(plugin->begin()))->reset();
+
+  ASSERT_EQ((*(plugin->begin()))->layerInitialized(), 1);
+  ASSERT_EQ(layers.areAllLayersInitialized(), 1);
+}
 
 int main(int argc, char** argv){
   ros::init(argc, argv, "inflation_tests");

--- a/costmap_2d/test/static_with_inflation_tests.cpp
+++ b/costmap_2d/test/static_with_inflation_tests.cpp
@@ -264,6 +264,23 @@ TEST(costmap, StaticLayerWithInflationMapReset){
   ASSERT_EQ(layers.areAllLayersInitialized(), 1);
 }
 
+/**
+ * Tests the reset method
+ */
+TEST(costmap, StaticLayerWithInflationMapReinitialize){
+
+  tf::TransformListener tf;
+  LayeredCostmap layers("frame", false, false);  // Not rolling window, not tracking unknown
+  addStaticLayerWithInflation(layers, tf);  // This adds the StaticLayerWithInflation map
+
+  std::vector<boost::shared_ptr<CostmapLayer>>* plugin = layers.getPlugins();
+
+  (*(plugin->begin()))->reinitialize();
+
+  ASSERT_EQ((*(plugin->begin()))->layerInitialized(), 1);
+  ASSERT_EQ(layers.areAllLayersInitialized(), 1);
+}
+
 int main(int argc, char** argv){
   ros::init(argc, argv, "inflation_tests");
   testing::InitGoogleTest(&argc, argv);

--- a/costmap_2d/test/static_with_inflation_tests.cpp
+++ b/costmap_2d/test/static_with_inflation_tests.cpp
@@ -202,7 +202,7 @@ TEST(costmap, testTimeMapUpdatesNew) {
 }
 
 /**
- * Tests the reset method
+ * Tests the onInitialize method
  */
 TEST(costmap, StaticLayerWithInflationMapOnInitialize){
 
@@ -216,7 +216,7 @@ TEST(costmap, StaticLayerWithInflationMapOnInitialize){
 }
 
 /**
- * Tests the reset method
+ * Tests the deactivate method
  */
 TEST(costmap, StaticLayerWithInflationMapDeactivated){
 
@@ -231,7 +231,7 @@ TEST(costmap, StaticLayerWithInflationMapDeactivated){
 }
 
 /**
- * Tests the reset method
+ * Tests the deactivate and activate method
  */
 TEST(costmap, StaticLayerWithInflationMapDeactivateAndActivate){
 


### PR DESCRIPTION
- All the layers of costmap are now aware of their state (whether they are initialized or not).
- The initialized_state is set to true in activate and onInitialize function and set to false in deactivate function.
- Add a function in layered_costmap to check if all the plugins(costmap_layers) are initialized or not.
- Add reinitialize function to all layers.
-Reinitailize function calls deactivate and activate in all the layers
